### PR TITLE
Add fix message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@closeio/test-console",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@closeio/test-console",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@closeio/test-console",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Library for handling console logs in tests in a flexible way",
   "keywords": [],
   "author": "Trey Cucco <trey.cucco@close.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { LogLevel, LogTest, ConsoleMethods } from './types';
-import { getLogLevel, getTestLocation } from './utils';
+import { getMatchingTest, getTestLocation } from './utils';
 import { levels } from './consts';
 
 export interface PatchConsoleMethodsOptions {
@@ -33,15 +33,19 @@ const patchConsoleMethods = (
 
     global.console[consoleMethod] = (...args) => {
       try {
-        const logLevel = getLogLevel(tests, args);
+        const match = getMatchingTest(tests, args);
 
-        if (logLevel === null || levels[logLevel] >= thresholdValue) {
+        if (match === null || levels[match.level] >= thresholdValue) {
           const location = getTestLocation({ filenameRegex, getTestName });
           originalMethod(
             ...args,
             /* c8 ignore next */
             location ? `\n\n${location}` : '',
           );
+          const fixMessage = match?.fix;
+          if (fixMessage) {
+            originalMethod(`Proposed fix: ${match.fix}`);
+          }
         }
       } catch (ex) {
         const location = getTestLocation({ filenameRegex, getTestName });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type ConsoleArgs = any[];
 export interface LogTest {
   matcher: Matcher;
   level: LogLevel;
+  fix?: string;
 }
 
 export type ConsoleMethod = (args: ConsoleArgs) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,21 +33,33 @@ export const getTestLocation = ({
 };
 
 // Given a list of test and the args passed to a console method, returns the
+// LogTest of the first test that matches the args. Or returns null if no
+// tests match the args.
+export const getMatchingTest = (
+  tests: LogTest[],
+  consoleArgs: ConsoleArgs,
+): LogTest | null => {
+  const args = prepareArgs(consoleArgs);
+
+  const matchingTest = tests.find(({ matcher }) => argsMatch(matcher, args));
+
+  if (matchingTest) {
+    return matchingTest;
+  }
+
+  return null;
+};
+
+// Given a list of test and the args passed to a console method, returns the
 // LogLevel of the first test that matches the args. Or returns null if no
 // tests match the args.
 export const getLogLevel = (
   tests: LogTest[],
   consoleArgs: ConsoleArgs,
 ): LogLevel | null => {
-  const args = prepareArgs(consoleArgs);
+  const matchingTest = getMatchingTest(tests, consoleArgs);
 
-  const matchingTest = tests.find(({ matcher }) => argsMatch(matcher, args));
-
-  if (matchingTest) {
-    return matchingTest.level;
-  }
-
-  return null;
+  return matchingTest?.level ?? null;
 };
 
 // Prepares console.log (and friends) args to be tested against string

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -16,7 +16,7 @@ describe('public api', () => {
         [
           { matcher: 'is info', level: 'INFO' },
           { matcher: 'is warning', level: 'WARNING' },
-          { matcher: 'is error', level: 'ERROR' },
+          { matcher: 'is error', level: 'ERROR', fix: 'this is a fix' },
         ],
         {
           filenameRegex: /\.test\.[jt]sx?/,
@@ -36,21 +36,25 @@ describe('public api', () => {
     describe('at threshold', () => {
       it('logs the message', () => {
         console.log('is warning');
-        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('above threshold', () => {
       it('logs the message', () => {
         console.error('is error');
-        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledTimes(2);
+        expect(errorSpy).toHaveBeenNthCalledWith(
+          2,
+          'Proposed fix: this is a fix',
+        );
       });
     });
 
     describe('no log matcher', () => {
       it('logs the message', () => {
         console.error('nothing matches this');
-        expect(errorSpy).toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledTimes(1);
       });
     });
 


### PR DESCRIPTION
## Background

Sometimes we want to mark something as an error and point people to the standard way to fix it.

## Description

Adds an optional `fix` option to the `LogTest` type and print this message out if present when a message matches that test.